### PR TITLE
fix(libs): Update download URLs

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -75,7 +75,7 @@ get_arch() {
   arch=$(uname -m | tr '[:upper:]' '[:lower]')
   case ${arch} in
   arm64)
-    arch='arm64-bit'
+    arch='arm64'
     ;;
   armv6l)
     arch='armv6'
@@ -84,7 +84,7 @@ get_arch() {
     arch='armv7'
     ;;
   x86_64)
-    arch='64-bit'
+    arch='amd64'
     ;;
   esac
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -40,7 +40,7 @@ download_release() {
   arch="$3"
   platform="$4"
 
-  url="$GH_REPO/releases/download/v${version}/${TOOL_NAME}_${version}_${platform}_${arch}.tar.gz"
+  url="$GH_REPO/releases/download/v${version}/${TOOL_NAME}_v${version}_${platform}_${arch}.tar.gz"
 
   echo "* Downloading $TOOL_NAME release $version..."
   curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"


### PR DESCRIPTION
These changes are intended to fix an install issue.

### Problem

Installs fail with a 404:

```
› asdf install vultr-cli latest
* Downloading vultr-cli release 3.3.1...
curl: (22) The requested URL returned error: 404
asdf-vultr-cli: Could not download https://github.com/vultr/vultr-cli/releases/download/v3.3.1/vultr-cli_3.3.1_macOs_arm64-bit.tar.gz
```

### Solution

Use new download URLs from [latest release](https://github.com/vultr/vultr-cli/releases/latest):

<img width="396" alt="Screenshot 2024-10-20 at 16 57 26" src="https://github.com/user-attachments/assets/9a8d6977-1343-4f1e-bc34-42a6437a3093">

Verified with my fork locally:

```
› asdf plugin add vultr-cli https://github.com/defrank/asdf-vultr-cli.git
› asdf install vultr-cli latest
* Downloading vultr-cli release 3.3.1...
vultr-cli 3.3.1 installation was successful!

› asdf list-all vultr-cli
0.1.0
0.1.1
0.1.2
0.1.3
0.1.4
0.1.5
0.1.6
0.1.7
0.1.8
0.1.9
0.1.10
0.1.11
0.2.0
0.2.1
0.3.0
0.3.1
0.3.2
0.4.0
1.0.0
2.0.0
2.0.1
2.1.0
2.2.0
2.3.0
2.4.0
2.4.1
2.5.0
2.5.1
2.5.2
2.5.3
2.6.0
2.7.0
2.8.0
2.8.1
2.8.2
2.8.3
2.8.4
2.8.5
2.9.0
2.10.0
2.11.0
2.11.1
2.11.2
2.11.3
2.12.0
2.12.1
2.12.2
2.13.0
2.14.0
2.14.1
2.14.2
2.15.0
2.15.1
2.16.0
2.16.1
2.16.2
2.17.0
2.18.0
2.18.1
2.18.2
2.19.0
2.20.0
2.21.0
2.22.0
3.0.0
3.0.1
3.0.2
3.0.3
3.1.0
3.2.0
3.3.0
3.3.1
```